### PR TITLE
Add `.github/CODEOWNERS` file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @bloomberg/blazingmq-sdk-python-maintainers


### PR DESCRIPTION
This patch adds a `CODEOWNERS` file, which automatically attaches @bloomberg/blazingmq-sdk-python-maintainers to newly-opened pull requests.