### PR TITLE
ci: Turn off docs publishing job

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -159,34 +159,3 @@ jobs:
         with:
           skip_existing: true
           password: ${{ secrets.PYPI_PASSWORD }}
-
-  publish_docs:
-    name: Publish docs
-    runs-on: ubuntu-latest
-    if: github.event_name == 'release' && github.event.action == 'published'
-    permissions:
-      contents: write
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: "3.10"
-      - name: Set up dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -qy clang-format pkg-config
-      - name: Install Python dependencies
-        run: |
-          python3 -m pip install -r requirements-lint-docs.txt
-      - name: Install Package
-        run: |
-          python3 -m pip install -e .
-      - name: Build docs
-        run: |
-          make docs
-      - name: Publish docs to GitHub Pages
-        uses: JamesIves/github-pages-deploy-action@v4
-        with:
-          folder: docs/_build/html
-          single-commit: true


### PR DESCRIPTION
Because we host our Python API documentation on the main BlazingMQ repository, we are not able to use a GitHub action as simple as this to generate and update the documentation.  This patch removes this action.  For the moment, we will update the documentation manually on release, but we may bring this back in a smarter way, or move the SDK documentation into this repository in the future.