### PR TITLE
docs: Explicitly document underlying `BMQ_BROKER_URI` behavior

### DIFF
--- a/src/blazingmq/_session.py
+++ b/src/blazingmq/_session.py
@@ -220,7 +220,9 @@ class Session:
             received by the session.
         on_message: an optional callback to process `Message` objects received
             by the session.
-        broker: TCP address of the broker (default: 'tcp://localhost:30114')
+        broker: TCP address of the broker (default: 'tcp://localhost:30114').
+            If the environment variable ``BMQ_BROKER_URI`` is set, its value
+            will override whatever broker address is passed via this argument.
         message_compression_algorithm: the type of compression to apply to messages
             being posted via this session object.
         timeout: maximum number of seconds to wait for requests on this


### PR DESCRIPTION
`libbmq` supports a `BMQ_BROKER_URI` environment variable, which when set, [overrides any broker URI passed in through the `SessionOptions`][envvar].  As the Python SDK is a set of bindings on top of `libbmq`, we inherit this behavior as well.  More specifically, setting `BMQ_BROKER_URI` overrides whatever value is passed in with the `broker` argument to the `blazingmq.Session` object.  Our integration tests use the environment variable in this way, so it is important to document it correctly.

This patch documents this behavior, which is stable and supported in `libbmq`, is exposed through the Python SDK, and is used by the Python SDK’s tests.

[envvar]: https://bloomberg.github.io/blazingmq/docs/apidocs/cpp_apidocs/group__bmqa__session.html