### PR TITLE
Turn on typechecking in our GitHub CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,7 @@ lint:
 	$(PYTHON) -m flake8 --config=$(CURDIR)/tests/.flake8 tests
 	$(PYTHON) -m flake8 --config=$(CURDIR)/tests/.flake8 examples
 	$(PYTHON) -m isort --check-only --settings-path=$(CURDIR)/.isort.cfg src tests examples setup.py
-	MYPYPATH=src $(PYTHON) -m mypy --strict examples
+	MYPYPATH=src $(PYTHON) -m mypy --strict examples src
 	clang-format --Werror --dry-run src/cpp/*
 
 # https://www.npmjs.com/package/markdownlint-cli

--- a/news/6.feature.rst
+++ b/news/6.feature.rst
@@ -1,0 +1,1 @@
+Enabled source code typechecking in the GitHub CI

--- a/src/blazingmq/_callbacks.py
+++ b/src/blazingmq/_callbacks.py
@@ -100,9 +100,7 @@ def on_session_event(
     user_callback(event)
 
 
-PropertiesAndTypesDictsType = Tuple[
-    Dict[str, Union[int, bytes]], Dict[str, PropertyType]
-]
+PropertiesAndTypesDictsType = Tuple[Dict[str, Union[int, bytes]], Dict[str, int]]
 
 
 def on_message(
@@ -115,10 +113,11 @@ def on_message(
     assert ext_session is not None, "ext.Session has been deleted"
     for data, guid, queue_uri, properties_tuple in messages:
         properties, property_types = properties_tuple
-        for k, v in property_types.items():
-            property_types[k] = property_type_to_py[v]
+        property_types_py = {
+            k: property_type_to_py[v] for k, v in property_types.items()
+        }
         message = create_message(
-            data, guid, queue_uri.decode(), properties, property_types
+            data, guid, queue_uri.decode(), properties, property_types_py
         )
         message_handle = create_message_handle(message, ext_session)
         user_callback(message, message_handle)

--- a/src/blazingmq/_callbacks.py
+++ b/src/blazingmq/_callbacks.py
@@ -92,7 +92,7 @@ def on_session_event(
             event_cls = failure_class_by_success_class[event_cls]
 
         assert queue_uri
-        event = event_cls(queue_uri, msg)
+        event: SessionEvent = event_cls(queue_uri, msg)
     else:
         event = event_cls(msg)
 

--- a/src/blazingmq/_callbacks.py
+++ b/src/blazingmq/_callbacks.py
@@ -29,9 +29,9 @@ from typing import Type
 from typing import Union
 import weakref
 
+from ._enums import AckStatus
 from ._enums import PropertyType
 from ._messages import Ack
-from ._messages import AckStatus
 from ._messages import Message
 from ._messages import create_ack
 from ._messages import create_message

--- a/src/blazingmq/_callbacks.py
+++ b/src/blazingmq/_callbacks.py
@@ -33,6 +33,7 @@ from ._enums import AckStatus
 from ._enums import PropertyType
 from ._messages import Ack
 from ._messages import Message
+from ._messages import MessageHandle
 from ._messages import create_ack
 from ._messages import create_message
 from ._messages import create_message_handle
@@ -105,7 +106,7 @@ PropertiesAndTypesDictsType = Tuple[
 
 
 def on_message(
-    user_callback: Callable[[Message], None],
+    user_callback: Callable[[Message, MessageHandle], None],
     ext_session_wr: weakref.ref[_ext.Session],
     property_type_to_py: Mapping[int, PropertyType],
     messages: Iterable[Tuple[bytes, bytes, bytes, PropertiesAndTypesDictsType]],

--- a/src/blazingmq/_callbacks.py
+++ b/src/blazingmq/_callbacks.py
@@ -21,6 +21,7 @@ from typing import Any
 from typing import Callable
 from typing import Dict
 from typing import Iterable
+from typing import Mapping
 from typing import Optional
 from typing import TYPE_CHECKING
 from typing import Tuple
@@ -106,7 +107,7 @@ PropertiesAndTypesDictsType = Tuple[
 def on_message(
     user_callback: Callable[[Message], None],
     ext_session_wr: weakref.ref[_ext.Session],
-    property_type_to_py: Dict[int, PropertyType],
+    property_type_to_py: Mapping[int, PropertyType],
     messages: Iterable[Tuple[bytes, bytes, bytes, PropertiesAndTypesDictsType]],
 ) -> None:
     ext_session = ext_session_wr()

--- a/src/blazingmq/_script_name.py
+++ b/src/blazingmq/_script_name.py
@@ -22,5 +22,6 @@ import sys
 def get_script_name() -> bytes:
     if getattr(sys.modules.get("__main__"), "__file__", ""):
         name = sys.modules["__main__"].__file__
+        assert name is not None  # help the typechecker
         return os.fsencode(name)
     return b"py:UNKNOWN"

--- a/src/blazingmq/_typing.py
+++ b/src/blazingmq/_typing.py
@@ -13,13 +13,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Dict
+from typing import Mapping
 from typing import Union
 
 from ._enums import PropertyType
 
 PropertyValueType = Union[int, bytes, str]
 
-PropertyValueDict = Dict[str, PropertyValueType]
+PropertyValueDict = Mapping[str, PropertyValueType]
 
-PropertyTypeDict = Dict[str, PropertyType]
+PropertyTypeDict = Mapping[str, PropertyType]


### PR DESCRIPTION
We already typecheck our examples, but we haven't been checking that the type annotations we include in our main source code are correct.  This PR first turns on this type checking in our CI, and then fixes issues that the typechecker catches.

Closes: #6