### PR TITLE
ci: Update MacOSX deployment target

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -139,7 +139,7 @@ jobs:
           CIBW_PRERELEASE_PYTHONS: True
           CIBW_TEST_COMMAND: python3 -m pytest {project}/tests/unit
           CIBW_TEST_REQUIRES: pytest mock pkgconfig
-          MACOSX_DEPLOYMENT_TARGET: "11.0"
+          MACOSX_DEPLOYMENT_TARGET: "12.0"
 
       - uses: actions/upload-artifact@v3
         with:


### PR DESCRIPTION
The minimum version of OSX we support is 12.0; we explicitly set this in our CI.  However, we have one environment variable that was selecting version 11.0; this causes some spurious compile warnings:

    clang: warning: overriding '-mmacosx-version-min=11.0' option with
    '-target arm64-apple-macos12' [-Woverriding-t-option]

This patch updates the `MACOSX_DEPLOYMENT_TARGET` variable to `12.0`.