### PR TITLE
Support Cython 3 where available

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -87,6 +87,7 @@ jobs:
     strategy:
       matrix:
         python-version:
+          - "3.7"
           - "3.8"
           - "3.9"
           - "3.10"

--- a/news/18.feature.rst
+++ b/news/18.feature.rst
@@ -1,0 +1,1 @@
+Support building with Cython 3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,10 @@
 [build-system]
 
-requires = ["setuptools>=39.2.0",
-            "cython>=0.28.4",
-            "wheel>=0.31.0",
-            "pkgconfig>1.5.0"]
+requires = ['setuptools>=39.2.0',
+            'Cython>=0.28.4, <3; python_version < "3.8"',
+            'Cython >= 3, <4; python_version >= "3.8"',
+            'wheel>=0.31.0',
+            'pkgconfig>1.5.0']
 
 build-backend = "setuptools.build_meta"
 

--- a/requirements-test-coverage.txt
+++ b/requirements-test-coverage.txt
@@ -1,3 +1,4 @@
 -r requirements-test.txt
 pytest-cov
-Cython
+Cython >= 0.29, <3; python_version < "3.8"
+Cython >=3, <4; python_version >= "3.8"


### PR DESCRIPTION
We currently support Python interpreters 3.7 and newer, and Cython 3 supports Python interpreters 3.8 and newer.  This patch updates the pip dependencies dependencies to prefer Cython 3 for interpreters 3.8 and newer, keeping the older version of Cython as a dependency for interpreter 3.7.

Closes: #18 