### PR TITLE
Improve CI build wheel matrix

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -107,7 +107,8 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-12]
-        cibw_python: ["cp311-*"]
+        cibw_python:
+          ["cp37-*", "cp38-*", "cp39-*", "cp310-*", "cp311-*", "cp312-*"]
         cibw_arch: ["x86_64"]
 
     steps:

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -108,7 +108,7 @@ jobs:
       matrix:
         os: [macos-12]
         cibw_python: ["cp311-*"]
-        cibw_arch: ["x86_64", "arm64"]
+        cibw_arch: ["x86_64"]
 
     steps:
       - uses: actions/download-artifact@v3

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -61,7 +61,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         cibw_python:
-          ["cp38-*", "cp39-*", "cp310-*", "cp311-*", "cp312-*"]
+          ["cp37-*", "cp38-*", "cp39-*", "cp310-*", "cp311-*", "cp312-*"]
         cibw_arch: ${{ fromJSON(needs.choose_architectures.outputs.cibw_arches) }}
 
     steps:


### PR DESCRIPTION
This PR fixes some long-running wheel building errors due to cross-compilation, and also adds support for building for all supported versions of Python on all supported platforms.