### PR TITLE
CI: Update GitHub Actions to use Node.js 20

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -104,7 +104,7 @@ jobs:
       - name: Restore cached BlazingMQ build artifacts
         run: tar xzf blazingmq_artifacts.tar.gz
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Create virtual environment
@@ -155,7 +155,7 @@ jobs:
       - name: Restore cached BlazingMQ build artifacts
         run: tar xzf blazingmq_artifacts.tar.gz
       - name: Set up Python 3.9
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.9"
       - name: Create virtual environment
@@ -203,7 +203,7 @@ jobs:
       - name: Restore cached BlazingMQ build artifacts
         run: tar xzf blazingmq_artifacts.tar.gz
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.9"
       - name: Create virtual environment

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -18,24 +18,24 @@ jobs:
     name: Build source distribution
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Build sdist
         env:
           BLAZINGMQ_PYTHON_NO_PKGCONFIG: ’1’
         run: pipx run build --sdist
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: dist
           path: dist
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: tests
           path: tests
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: bin
           path: bin
@@ -65,19 +65,19 @@ jobs:
         cibw_arch: ${{ fromJSON(needs.choose_architectures.outputs.cibw_arches) }}
 
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: dist
           path: dist
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: tests
           path: tests
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: bin
           path: bin
-      - uses: docker/setup-qemu-action@v2
+      - uses: docker/setup-qemu-action@v3
         if: runner.os == 'Linux'
         name: Set up QEMU
       - name: Extract sdist
@@ -87,14 +87,14 @@ jobs:
         run: |
           echo 0 | sudo tee /proc/sys/kernel/yama/ptrace_scope
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.15.0
+        uses: pypa/cibuildwheel@v2.16.2
         env:
           CIBW_ARCHS_LINUX: ${{ matrix.cibw_arch }}
           CIBW_BUILD: ${{ matrix.cibw_python }}
           CIBW_PRERELEASE_PYTHONS: True
           CIBW_TEST_COMMAND: python3 -m pytest {project}/tests/unit
           CIBW_TEST_REQUIRES: pytest mock pkgconfig
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: dist
           path: ./wheelhouse/*.whl
@@ -112,15 +112,15 @@ jobs:
         cibw_arch: ["x86_64"]
 
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: dist
           path: dist
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: tests
           path: tests
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: bin
           path: bin
@@ -132,7 +132,7 @@ jobs:
         run: |
           echo "CFLAGS=-target arm64-apple-macos12" >> $GITHUB_ENV
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.15.0
+        uses: pypa/cibuildwheel@v2.16.2
         env:
           CIBW_ARCHS_MACOS: ${{ matrix.cibw_arch }}
           CIBW_BUILD: ${{ matrix.cibw_python }}
@@ -142,7 +142,7 @@ jobs:
           CIBW_TEST_REQUIRES: pytest mock pkgconfig
           MACOSX_DEPLOYMENT_TARGET: "12.0"
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: dist
           path: ./wheelhouse/*.whl
@@ -152,7 +152,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'release' && github.event.action == 'published'
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: dist
           path: dist


### PR DESCRIPTION
Our CI has been admonishing us to use more recent versions of certain GitHub Actions, like `actions/checkout`, which are built on Node.js version 20 instead of the older Node.js version 16.  This transition is documented [here][actions-transition].

This patch updates the actions we can to ones that are built on Node.js 20:

  - `actions/checkout@v3`          → `actions/checkout@v4`
  - `actions/upload-artifact@v3`   → `actions/upload-artifact@v4`
  - `actions/download-artifact@v3` → `actions/download-artifact@v4`
  - `actions/setup-python@v4`      → `actions/setup-python@v5`
  - `docker/setup-qemu-action@v2`  → `actions/setup-qemu-action@v3`

This patch also uses this opportunity to update our dependency on `pypa/cibuildwheel` from `v2.15.0` to the latest version, `v2.16.2`.

[actions-transition]: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/

<!-- Make sure your PR is linked to an issue as described in the
CONTRIBUTING.md document. Place the issue number under the PR description
after the '#' character. -->

Closes: #21 