### PR TITLE
CI: Fix MacOS 11/12 issue building with Python 3.7/3.8

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -141,6 +141,8 @@ jobs:
           CIBW_TEST_COMMAND: python3 -m pytest {project}/tests/unit
           CIBW_TEST_REQUIRES: pytest mock pkgconfig
           MACOSX_DEPLOYMENT_TARGET: "12.0"
+          MACOS_DEPLOYMENT_TARGET: "12.0"
+          SYSTEM_VERSION_COMPAT: 0
 
       - uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
There is a known issue with pip on Python 3.7 and 3.8 where [wheels can’t be installed on MacOS 11.0 or higher][pip-wheels], even if they were successfully built with on the same machine.  This is causing our integration tests to fail in CI for these platforms.  Apparently, the fix is to set the environment variable `SYSTEM_VERSION_COMPAT` to `0`, as in [this patch][fix].  The current patch enables this same environment variable.

[pip-wheels]: https://github.com/pypa/cibuildwheel/issues/1410
[fix]: https://github.com/gpongelli/pycode128/commit/066cb37f1cc37354e58c05d69c23e9ec1728138f