### PR TITLE
CI: [fixup] Use correct paths when uploading sdist artifacts

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -28,17 +28,17 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           name: dist-sdist
-          path: dist-sdist
+          path: dist
 
       - uses: actions/upload-artifact@v4
         with:
           name: tests-sdist
-          path: tests-sdist
+          path: tests
 
       - uses: actions/upload-artifact@v4
         with:
           name: bin-sdist
-          path: bin-sdist
+          path: bin
 
   choose_architectures:
     name: Decide which architectures to build wheels for


### PR DESCRIPTION
The previous PR was overzealous in changing some names, again causing every job in the build matrix to fail.