### PR TITLE
CI: Update pypa/cibuildwheel version

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -87,7 +87,7 @@ jobs:
         run: |
           echo 0 | sudo tee /proc/sys/kernel/yama/ptrace_scope
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.16.2
+        uses: pypa/cibuildwheel@v2.16.5
         env:
           CIBW_ARCHS_LINUX: ${{ matrix.cibw_arch }}
           CIBW_BUILD: ${{ matrix.cibw_python }}-*
@@ -132,7 +132,7 @@ jobs:
         run: |
           echo "CFLAGS=-target arm64-apple-macos12" >> $GITHUB_ENV
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.16.2
+        uses: pypa/cibuildwheel@v2.16.5
         env:
           CIBW_ARCHS_MACOS: ${{ matrix.cibw_arch }}
           CIBW_BUILD: ${{ matrix.cibw_python }}-*


### PR DESCRIPTION
The new `cibuildwheel` version updates its internal `setup-python` action to version `v5`, which uses Node.js version 20 instead of version 16.  Using this new version should finally silence the remaining warning about using actions built on Node.js version 16.  Additionally, the new version of `cibuildwheel` includes experimental support for using GitHub M1 runners, which will enable us to test and build wheels on this architecture.

This patch updates all uses of `cibuildwheel` to this new version.