### PR TITLE
CI: Allow PyPI publishing to be done manually

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -5,6 +5,7 @@ on:
   release:
     types:
       - published
+  workflow_dispatch:
   schedule:
     # At 12:00 on every day-of-month
     - cron: "0 12 */1 * *"
@@ -161,7 +162,9 @@ jobs:
   upload_pypi:
     needs: merge
     runs-on: ubuntu-latest
-    if: github.event_name == 'release' && github.event.action == 'published'
+    if: |
+      github.event_name == 'release' && github.event.action == 'published'
+        || github.event_name == 'workflow_dispatch'
     steps:
       - uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
We have occassionally gotten transient GitHub Action failures that seem to be due to GitHub’s infrastructure, rather than our own workflows.  In the case of creating a new GitHub release, this may result in a failure to upload the build wheels to PyPI.  For that reason, it is useful to be able to dispatch a PyPI upload manually, without creating a new GitHub release.  This patch enables the `workflow_dispatch` trigger for our `wheels`, and explicitly allows `upload_pypi` to run on `workflow_dispatch`, which allows us to manually and intentionally call this workflow without making a new release.

We want this to be run intentionally, though, so it’s important to note that to trigger a `workflow_dispatch` event, the workflow has to be on `main`.  This means we cannot publish from a branch or PR that has not yet been merged.  Because the primary use case of this is to try publishing a PyPI upload again after a transient failure due to GitHub’s infrastructure, this restriction is useful.

This patch was originally part of PR #30, but separating it out for its own review is important.  Adding this infrastructure will give us a hook to update our GitHub docs without making a new release.