### PR TITLE
Use proper timeout in `test_examples.py`

### DIFF
--- a/tests/integration/test_examples.py
+++ b/tests/integration/test_examples.py
@@ -111,12 +111,12 @@ def test_example_consumer(unique_queue, script):
 
     time.sleep(5.0)
     process.terminate()
-    time.sleep(0.1)
-    if process.returncode is None and process.poll() is None:
+    try:
+        stdout, stderr = process.communicate(timeout=2.0)
+    except subprocess.TimeoutExpired:
         print("terminate failed, killing process")
         process.kill()
-
-    stdout, stderr = process.communicate()
+        stdout, stderr = process.communicate()
 
     # THEN
     assert ack.status == AckStatus.SUCCESS


### PR DESCRIPTION
When the broker is slow to terminate, this test may fail.  Rather than using `sleep` and polling whether the process has sucessfully terminated, as we’ve done in this test previously, we can instead use the `timeout` argument of `Popen.communicate` to wait for the broker to terminate.

This patch does two things: first, it increases the timeout after the broker has been terminated until we decide to kill the broker from 0.1 seconds to 2.0 seconds.  This is still a short wait, but it gives a slow broker much more time to gracefully shut down.  Second, it switches from `sleep`-and-poll to using the `Popen.communicate` function with a timeout to wait until the process has terminated.  The exact idiom used in this patch is given in the [documentation for this function][communicate]; the double call to `communicate` is explained there by the note:

    If the process does not terminate after timeout seconds, a
    `TimeoutExpired` exception will be raised.  Catching this
    exception and retrying communication will not lose any output.

Because of this, the two calls to `communicate` are safe, and we only need the output of the latest call.

[communicate]: https://docs.python.org/3/library/subprocess.html#subprocess.Popen.communicate