### PR TITLE
Update `QueueOptions` docs and examples

### DIFF
--- a/examples/consumer.py
+++ b/examples/consumer.py
@@ -41,7 +41,14 @@ def main() -> None:
 
         EXITING.wait()
         print("Waiting to process all outstanding messages")
-        session.configure_queue(QUEUE_URI, blazingmq.QueueOptions(0, 0, 0))
+        session.configure_queue(
+            QUEUE_URI,
+            blazingmq.QueueOptions(
+                max_unconfirmed_messages=0,  # 0 means no limit
+                max_unconfirmed_bytes=0,  # 0 means no limit
+                consumer_priority=0,
+            ),
+        )
     print("Session stopped.")
 
 

--- a/examples/consumer2.py
+++ b/examples/consumer2.py
@@ -55,7 +55,14 @@ def main() -> None:
             print("Confirming: ", msg)
             session.confirm(msg)
         print("Waiting to receive all outstanding messages")
-        session.configure_queue(QUEUE_URI, blazingmq.QueueOptions(0, 0, 0))
+        session.configure_queue(
+            QUEUE_URI,
+            blazingmq.QueueOptions(
+                max_unconfirmed_messages=0,  # 0 means no limit
+                max_unconfirmed_bytes=0,  # 0 means no limit
+                consumer_priority=0,
+            ),
+        )
 
     print("Session stopped.")
 

--- a/src/blazingmq/_session.py
+++ b/src/blazingmq/_session.py
@@ -162,15 +162,16 @@ class QueueOptions:
     Args:
         max_unconfirmed_messages:
             The maximum number of messages that can be delivered to the queue
-            without confirmation. This limit can be reached if the queue
-            receives messages faster than it confirms received messages. Once
-            this limit is reached, at least one message must be confirmed
-            before the queue will receive any more messages.
+            without confirmation. If 0, no limit is imposed.  This limit can be
+            reached if the queue receives messages faster than it confirms
+            received messages. Once this limit is reached, at least one message
+            must be confirmed before the queue will receive any more messages.
         max_unconfirmed_bytes:
             The maximum number of bytes that can be delivered to the queue
-            without confirmation. Like *max_unconfirmed_messages*, this limit
-            can be reached if incoming messages are queued up waiting for
-            already delivered messages to be confirmed.
+            without confirmation. If 0, no limit is imposed.  Like
+            *max_unconfirmed_messages*, this limit can be reached if incoming
+            messages are queued up waiting for already delivered messages to be
+            confirmed.
         consumer_priority:
             The precedence of this consumer compared to other consumers of the
             same queue. The consumer with the highest priority receives the


### PR DESCRIPTION
While investigating a user's consumer code, I was confused by the expression `QueueOptions(0, 0, 0)`, which was taken from our example code.  Our docs did not shed any light.  The investigation documented in the commit message in this PR led me to find that our documentation is incorrect for `max_unconfirmed_messages` and `max_unconfirmed_bytes`.

The changes in this PR are meant to avert other users from having the same confusion I faced: (1) improve the documentation for these queue options in the Python SDK, taking the behavior documented in the C++ SDK and adding it to the Python docs, and (2) changing the example consumers we provide from using positional arguments to named arguments, so it is more clear from looking at the examples what queue options we're setting.  The latter change makes it a little more apparent that we are not using the default queue options in these example consumers.

Closes: #36