### PR TITLE
Make `post` return message GUID

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -137,7 +137,7 @@ jobs:
         run: |
           mkdir -p bmq/logs
           mkdir -p bmq/storage/archive
-          ./blazingmq_artifacts/bin/bmqbrkr.tsk ./tests/broker-config &
+          ./blazingmq_artifacts/bin/bmqbrkr.tsk ./tests/broker-config >/dev/null &
           (sleep 5; make test-build && make test-install && make check)
 
   lint-docs:
@@ -222,7 +222,7 @@ jobs:
         run: |
           mkdir -p bmq/logs
           mkdir -p bmq/storage/archive
-          ./blazingmq_artifacts/bin/bmqbrkr.tsk ./tests/broker-config &
+          ./blazingmq_artifacts/bin/bmqbrkr.tsk ./tests/broker-config >/dev/null &
           (sleep 5; make coverage-install && make coverage)
       - name: Output code coverage summary
         uses: irongut/CodeCoverageSummary@v1.3.0

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Try to get cached BlazingMQ build artifacts
         id: cache-restore
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v4
         with:
           path: blazingmq_artifacts.tar.gz
           key: ${{ steps.get-sha.outputs.blazingmq_sha }}
@@ -75,7 +75,7 @@ jobs:
       - name: Cache built BlazingMQ build artifacts
         id: cache-save
         if: steps.cache-restore.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v3
+        uses: actions/cache/save@v4
         with:
           path: blazingmq_artifacts.tar.gz
           key: ${{ steps.get-sha.outputs.blazingmq_sha }}
@@ -97,7 +97,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Try to get cached BlazingMQ build artifacts
         id: cache-restore
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v4
         with:
           path: blazingmq_artifacts.tar.gz
           key: ${{ needs.blazingmq-dependency.outputs.blazingmq_sha }}
@@ -148,7 +148,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Try to get cached BlazingMQ build artifacts
         id: cache-restore
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v4
         with:
           path: blazingmq_artifacts.tar.gz
           key: ${{ needs.blazingmq-dependency.outputs.blazingmq_sha }}
@@ -196,7 +196,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Try to get cached BlazingMQ build artifacts
         id: cache-restore
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v4
         with:
           path: blazingmq_artifacts.tar.gz
           key: ${{ needs.blazingmq-dependency.outputs.blazingmq_sha }}

--- a/news/38.feature.rst
+++ b/news/38.feature.rst
@@ -1,0 +1,1 @@
+Make `Session.post` return the message GUID.

--- a/src/blazingmq/_ext.pyi
+++ b/src/blazingmq/_ext.pyi
@@ -78,7 +78,7 @@ class Session:
         *,
         properties: Optional[Dict[bytes, Tuple[Union[int, bytes], int]]] = None,
         on_ack: Optional[Callable[[Ack], None]] = None,
-    ) -> None: ...
+    ) -> bytes: ...
     def configure_queue_sync(
         self,
         queue_uri: bytes,

--- a/src/blazingmq/_ext.pyx
+++ b/src/blazingmq/_ext.pyx
@@ -333,8 +333,13 @@ cdef class Session:
              queue_uri not None: bytes,
              payload not None: bytes,
              properties=None,
-             on_ack=None) -> None:
-        self._session.post(queue_uri, payload, len(payload), properties, on_ack)
+             on_ack=None) -> bytes:
+        return self._session.post(
+            queue_uri,
+            payload,
+            len(payload),
+            properties,
+            on_ack)
 
     def confirm(self, message not None) -> None:
         self._session.confirm(message.queue_uri, message.guid, len(message.guid))

--- a/src/blazingmq/_session.py
+++ b/src/blazingmq/_session.py
@@ -716,7 +716,7 @@ class Session:
         properties: Optional[PropertyValueDict] = None,
         property_type_overrides: Optional[PropertyTypeDict] = None,
         on_ack: Optional[Callable[[Ack], None]] = None,
-    ) -> None:
+    ) -> bytes:
         """Post a message to an opened queue specified by *queue_uri*.
 
         Post the payload and optional properties and overrides to the opened
@@ -734,6 +734,9 @@ class Session:
                 specified callback which is invoked with the acknowledgment
                 status of the message being posted.
 
+        Returns:
+            `bytes`: The posted message's GUID.
+
         Raises:
             `~blazingmq.Error`: If the post request was not successful.
         """
@@ -741,7 +744,7 @@ class Session:
         if properties or property_type_overrides:
             props = _collect_properties_and_types(properties, property_type_overrides)
 
-        self._ext.post(
+        return self._ext.post(
             six.ensure_binary(queue_uri),
             message,
             properties=props,

--- a/tests/integration/test_post.py
+++ b/tests/integration/test_post.py
@@ -157,13 +157,14 @@ def test_post_with_successful_ack(default_session, unique_queue, zeroed_queue_op
         q.put(*args)
 
     # WHEN
-    default_session.post(unique_queue, b"hello", on_ack=go_on)
+    guid = default_session.post(unique_queue, b"hello", on_ack=go_on)
     ack = q.get()
 
     # THEN
     assert ack.status == AckStatus.SUCCESS
     assert isinstance(ack.guid, bytes)
     assert len(ack.guid) == 16
+    assert ack.guid == guid
     assert ack.queue_uri == unique_queue
 
 


### PR DESCRIPTION
The API already allows correlating PUTs and ACKs by passing different `on_ack` callbacks for each message---storing some data in the closure of the callback, for instance.  This patch makes the easy enhancement to make `post` return the message GUID on each call.

<!-- Make sure your PR is linked to an issue as described in the
CONTRIBUTING.md document. Place the issue number under the PR description
after the '#' character. -->

Closes: #38 