### PR TITLE
Add example of a producer that correlates posts with acks/nacks

### DIFF
--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -45,6 +45,12 @@ make test-install
 BMQ_BROKER_URI=tcp://localhost:30114 make check
 ```
 
+Note that on OSX, the
+`tests/integration/test_deadlock_detection.py::test_deadlock_detection_warning`
+test may display a dialog warning you of a crashed Python process,
+depending on your system configuration.  This crash is intentional, and
+is part of the test.
+
 Additional `make` targets are provided, such as for test coverage.
 Dependencies for these can be installed as follows:
 

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -17,6 +17,23 @@ in a fully synchronous fashion - the program waits for an acknowledgement before
 
 .. literalinclude:: ../examples/producer.py
 
+Producer with Correlation ID
+=================================
+
+A complete example of a program that posts a series of messages with
+identifiers that can be used to correlate the Ack or Nack from the broker with
+the posted message.
+
+Unlike the BlazingMQ C++ SDK, which has a concept “correlation id”, which can
+be provided with every posted message and will be provided back to the producer
+with an Ack or Nack from the broker, the BlazingMQ Python SDK does not provide
+this as a first-class notion.  Instead, in Python, a different ``on_ack``
+callback can be provided on each posted message, storing arbitrary data in its
+closure.  Using ``functools.partial``, we can construct these lightweight
+callback closures to add a correlation id, or any arbitrary identifying data.
+
+.. literalinclude:: ../examples/producer_with_correlation.py
+
 Consumer with `threading.Event`
 =================================
 

--- a/examples/producer_with_correlation.py
+++ b/examples/producer_with_correlation.py
@@ -1,0 +1,48 @@
+# Copyright 2019-2023 Bloomberg Finance L.P.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import functools
+import time
+
+import blazingmq
+
+QUEUE_URI = "bmq://bmq.test.mmap.priority/blazingmq-examples"
+MSG_COUNT = 10
+
+
+def on_ack(msg_id: int, ack: blazingmq.Ack) -> None:
+    if ack.status != blazingmq.AckStatus.SUCCESS:
+        print(f"Received NAck for message number {msg_id}: {repr(ack)}")
+    else:
+        print(f"Received Ack for message number {msg_id}: {repr(ack)}")
+
+
+def main() -> None:
+    with blazingmq.Session(blazingmq.session_events.log_session_event) as session:
+        print("Connected to BlazingMQ broker")
+        session.open_queue(QUEUE_URI, write=True)
+        for msg_id in range(0, MSG_COUNT):
+            on_ack_with_id = functools.partial(on_ack, msg_id)
+            print(f"Posting message number {msg_id}")
+            session.post(QUEUE_URI, b"\xde\xad\x00\x00\xbe\xef", on_ack=on_ack_with_id)
+        # Wait a short amount of time for all messages to be Ack'd or Nack'd.
+        # In a production scenario, you will want a more robust solution than this.
+        time.sleep(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/news/42.doc.rst
+++ b/news/42.doc.rst
@@ -1,0 +1,1 @@
+Add example of correlating a message’s post with its ack/nack

--- a/tests/integration/test_deadlock_detection.py
+++ b/tests/integration/test_deadlock_detection.py
@@ -13,6 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# N.B. On OSX, the
+# `tests/integration/test_deadlock_detection.py::test_deadlock_detection_warning`
+# test may display a dialog warning you of a crashed Python process, depending
+# on your system configuration.  This crash is intentional, and is part of the
+# test.
+
 import signal
 import subprocess
 import sys

--- a/tests/integration/test_examples.py
+++ b/tests/integration/test_examples.py
@@ -82,6 +82,8 @@ def test_example_producer(unique_queue):
 
     # THEN
     session.stop()
+    process.wait()
+    assert q.empty()
     assert msg.data == b"\xde\xad\x00\x00\xbe\xef"
     assert msg.queue_uri == unique_queue
     assert msg.properties == {}


### PR DESCRIPTION
We've had several users ask us how to correlate a message's post with its ack or nack.  The way we intend is to provide a different closure for each message's `on_ack`, including any information that that callback may need to correlate the message.  This PR introduces an example documenting this.

There are three patches in this PR:

  1. **Add post/ack correlation example.**  Here, we add a simple example of a producer that correlates posts with acks or nacks.  We also add this to the test suite, to ensure that the example works as intended.
  
  2. **Extend the existing producer test with additional checks.**  The new producer example test has some additional checks that also make sense in the existing producer example test, so we also add them there.
  
  3. **Document an expected crash dialog on OSX when running integration tests.**  This test induces a deadlock so that it can verify that the library detects that deadlock.  On Linux machines, the deadlock crash is silent as well as intentional.  However, on OSX machines, depending on their configuration, each crash causes a dialog box to appear, telling the user that a crash occurred.  This is annoying, but it is a product of the intention of the test.

Closes: #42 