### PR TITLE
Fix Tests and Wheels pipelines

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -87,8 +87,6 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - "3.7"
-          - "3.8"
           - "3.9"
           - "3.10"
           - "3.11"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,7 +13,7 @@ concurrency:
 jobs:
   blazingmq-dependency:
     name: Build BlazingMQ as a dependency
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     outputs:
       blazingmq_sha: ${{ steps.get-sha.outputs.blazingmq_sha }}
     steps:
@@ -83,7 +83,7 @@ jobs:
   linux-check:
     name: Test on Linux
     needs: blazingmq-dependency
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         python-version:
@@ -141,7 +141,7 @@ jobs:
   lint-docs:
     name: Lint and Docs
     needs: blazingmq-dependency
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - name: Try to get cached BlazingMQ build artifacts
@@ -189,7 +189,7 @@ jobs:
   coverage:
     name: Coverage
     needs: blazingmq-dependency
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - name: Try to get cached BlazingMQ build artifacts

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -62,7 +62,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         cibw_python:
-          ["cp37", "cp38", "cp39", "cp310", "cp311", "cp312"]
+          ["cp39", "cp310", "cp311", "cp312"]
         cibw_arch: ${{ fromJSON(needs.choose_architectures.outputs.cibw_arches) }}
 
     steps:
@@ -88,7 +88,7 @@ jobs:
         run: |
           echo 0 | sudo tee /proc/sys/kernel/yama/ptrace_scope
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.16.5
+        uses: pypa/cibuildwheel@v2.19.2
         env:
           CIBW_ARCHS_LINUX: ${{ matrix.cibw_arch }}
           CIBW_BUILD: ${{ matrix.cibw_python }}-*
@@ -107,10 +107,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-12]
+        os: [macos-14]
         cibw_python:
-          ["cp37", "cp38", "cp39", "cp310", "cp311", "cp312"]
-        cibw_arch: ["x86_64"]
+          ["cp39", "cp310", "cp311", "cp312"]
+        cibw_arch: ["arm64"]
 
     steps:
       - uses: actions/download-artifact@v4
@@ -131,9 +131,9 @@ jobs:
       - name: Sets env vars for compilation
         if: matrix.cibw_arch == 'arm64'
         run: |
-          echo "CFLAGS=-target arm64-apple-macos12" >> $GITHUB_ENV
+          echo "CFLAGS=-target arm64-apple-macos14" >> $GITHUB_ENV
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.16.5
+        uses: pypa/cibuildwheel@v2.19.2
         env:
           CIBW_ARCHS_MACOS: ${{ matrix.cibw_arch }}
           CIBW_BUILD: ${{ matrix.cibw_python }}-*
@@ -141,8 +141,8 @@ jobs:
           CIBW_PRERELEASE_PYTHONS: True
           CIBW_TEST_COMMAND: python3 -m pytest {project}/tests/unit
           CIBW_TEST_REQUIRES: pytest mock pkgconfig
-          MACOSX_DEPLOYMENT_TARGET: "12.0"
-          MACOS_DEPLOYMENT_TARGET: "12.0"
+          MACOSX_DEPLOYMENT_TARGET: "14.0"
+          MACOS_DEPLOYMENT_TARGET: "14.0"
           SYSTEM_VERSION_COMPAT: 0
 
       - uses: actions/upload-artifact@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ filename    = "CHANGELOG.md"
 directory   = "news"
 
 [tool.cibuildwheel]
-build = ["cp38-*", "cp39-*", "cp310-*", "cp311-*"]
+build = ["cp39-*", "cp310-*", "cp311-*", "cp312-*"]
 skip = "*-musllinux_*"
 manylinux-x86_64-image = "manylinux2014"
 manylinux-i686-image = "manylinux2014"

--- a/setup.py
+++ b/setup.py
@@ -196,8 +196,6 @@ setup(
         "Intended Audience :: Developers",
         "Operating System :: POSIX :: Linux",
         "Development Status :: 5 - Production/Stable",
-        "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
@@ -216,6 +214,6 @@ setup(
         include_path=["src/declarations"],
         compiler_directives=COMPILER_DIRECTIVES,
     ),
-    python_requires=">=3.7",
+    python_requires=">=3.9",
     zip_safe=False,
 )

--- a/src/cpp/pybmq_messageutils.cpp
+++ b/src/cpp/pybmq_messageutils.cpp
@@ -375,8 +375,8 @@ MessageUtils::load_message_properties(
     do {                                                                               \
         if (!PY_TYPE_FUNC(OBJECT)) {                                                   \
             bsl::ostringstream oss;                                                    \
-            oss << "'" << OBJECT_KEY << "' value is of the incorrect type, "           \
-                << "'" << Py_TYPE(OBJECT)->tp_name << "' provided, '" << EXPECTED_TYPE \
+            oss << "'" << OBJECT_KEY << "' value is of the incorrect type, " << "'"    \
+                << Py_TYPE(OBJECT)->tp_name << "' provided, '" << EXPECTED_TYPE        \
                 << "' expected.";                                                      \
             PyErr_SetString(PyExc_TypeError, oss.str().c_str());                       \
             return false;                                                              \


### PR DESCRIPTION
1. Fix "Lint and Docs" pipeline job. It was failing due to clang-format errors:

![Screenshot 2024-10-15 205548](https://github.com/user-attachments/assets/94054cf2-98f8-4491-8d9c-e0f842e4d524)

2. Fix "Test on Linux (3.7)" pipeline job. It was failing because **ubuntu-latest** image is used for test runs. And latest version is 24.04 where python 3.7 is not supported.

![image](https://github.com/user-attachments/assets/aa34277b-10ea-4854-9f5f-bdadef372901)

3. Fix Wheels pipeline for macos: newer macos runners (which provide XCode 15+ needed for C++17 features support) are provided only for Apple Silicon (arm64) arch. Testing of BDE and blazingmq main repo is done also only on macos arm64.

4. Fix Wheels pipeline for Linux.  Upgraded pypa/cibuildwheel to v2.19.2 which has fixes for CentOS 7 (which is EOL) mirrorlist to make `yum install` work.

![image](https://github.com/user-attachments/assets/bc0ca511-cc7e-4202-ae74-2b05a20c5fe0)
