### PR TITLE
Upload broker logs as artifacts on failure

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -226,3 +226,11 @@ jobs:
         uses: irongut/CodeCoverageSummary@v1.3.0
         with:
           filename: coverage*.xml
+      - name: Upload broker logs as artifacts
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: broker_logs
+          path: ./bmq/logs
+          retention-days: 5
+          compression-level: 9


### PR DESCRIPTION
In case when Coverage pipeline fails, the broker logs are uploaded as an artifact.

![Screenshot 2024-10-30 174557](https://github.com/user-attachments/assets/e8cf3a38-291c-46bc-8c05-640233120a54)
