### PR TITLE
Remove wheel build for Linux arm64

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -47,9 +47,6 @@ jobs:
     steps:
       - id: x86_64
         run: echo "cibw_arch=x86_64" >> $GITHUB_OUTPUT
-      - id: aarch64
-        if: github.event_name == 'release' && github.event.action == 'published'
-        run: echo "cibw_arch=aarch64" >> $GITHUB_OUTPUT
     outputs:
       cibw_arches: ${{ toJSON(steps.*.outputs.cibw_arch) }}
 


### PR DESCRIPTION
This patch removes Linux arm64 wheel builds from the release CI.  This workflow has never worked, and only fires on release.  Its failure blocks publishing binaries to PyPI automatically (though the manual workflow still works).

<!-- Make sure your PR is linked to an issue as described in the
CONTRIBUTING.md document. Place the issue number under the PR description
after the '#' character. -->

Closes: #49