### PR TITLE
Fix: Make CSL and FSM settings match

### DIFF
--- a/tests/broker-config/clusters.json
+++ b/tests/broker-config/clusters.json
@@ -3,7 +3,7 @@
         {
             "name": "local",
             "clusterAttributes": {
-                "isCSLModeEnabled": true,
+                "isCSLModeEnabled": false,
                 "isFSMWorkflow": false
             },
             "nodes": [


### PR DESCRIPTION
CSL and FSM are not fully supported yet, so we turn them off to avoid recent broker versions complaining.

<!-- Make sure your PR is linked to an issue as described in the
CONTRIBUTING.md document. Place the issue number under the PR description
after the '#' character. -->

Closes: #54 