### PR TITLE
Chore: Bump dependency versions (and bump version to 1.2.3 for release)

### DIFF
--- a/bin/build-macos-universal.sh
+++ b/bin/build-macos-universal.sh
@@ -68,6 +68,8 @@ if [ ! -e "${DIR_BUILD}/ntf-core/.complete" ]; then
         --output "${DIR_BUILD}/ntf-core" \
         --ufid opt_64_pic_cpp17 \
         --generator "Ninja" \
+        --without-lz4 \
+        --without-zstd \
         --without-warnings-as-errors \
         --without-usage-examples \
         --without-applications

--- a/bin/build-manylinux.sh
+++ b/bin/build-manylinux.sh
@@ -106,6 +106,8 @@ if [ ! -e "${DIR_BUILD}/ntf-core/.complete" ]; then
         --output "${DIR_BUILD}/ntf-core" \
         --ufid opt_64_pic_cpp17 \
         --generator "Ninja" \
+        --without-lz4 \
+        --without-zstd \
         --without-warnings-as-errors \
         --without-usage-examples \
         --without-applications

--- a/bin/clone-dependencies.sh
+++ b/bin/clone-dependencies.sh
@@ -12,10 +12,10 @@ set -u
 
 # These are the release tags for each of the dependencies we manually clone.
 # Update these to update the version of each dependency we build against.
-BDE_TOOLS_TAG=4.8.0.0
-BDE_TAG=4.8.0.0
-NTF_CORE_TAG=2.4.2
-BLAZINGMQ_TAG=BMQBRKR_0.92.5
+BDE_TOOLS_TAG=4.32.0.0
+BDE_TAG=4.32.0.0
+NTF_CORE_TAG=2.6.6
+BLAZINGMQ_TAG=BMQBRKR_0.94.8
 
 
 if [ ! -d "${DIR_THIRDPARTY}/bde-tools" ]; then

--- a/news/62.misc.rst
+++ b/news/62.misc.rst
@@ -1,0 +1,1 @@
+Bump build dependency versions of BDE, ntf-core, and BlazingMQ/libbmq

--- a/src/blazingmq/_about.py
+++ b/src/blazingmq/_about.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.2.2"
+__version__ = "1.2.3"


### PR DESCRIPTION
This patch bumps the dependency versions of BDE, ntf-core, and BlazingMQ/libbmq to the most recent released versions.  ntf-core has gained support for transport-level compression using zlib, lz4, and zstd, but since BlazingMQ does not use this and since we do not want a runtime dependency on the lz4 or zstd libraries, we disable these while building ntf-core.

Closes: #62 