### PR TITLE
CI: Use new `ubuntu-slim` runners for lightweight checks

### DIFF
--- a/.github/workflows/dco-check.yaml
+++ b/.github/workflows/dco-check.yaml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   commits_check_job:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     name: Commits Check
     steps:
       - name: Get PR Commits

--- a/.github/workflows/news-check.yaml
+++ b/.github/workflows/news-check.yaml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   news_entry_check:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     name: Check for news entry
     steps:
       - name: "Check for news entry"


### PR DESCRIPTION
For lightweight checks, we can use the new [`ubuntu-slim` runners][ubuntu-slim], which use containers rather than full VMs, and provide 1 vCPU and 5GB of RAM.  Jobs that can use these should be scheduled more quickly with these new runners.

This patch migrates our DCO Check and News Check jobs to `ubuntu-slim` runners.

[ubuntu-slim]: https://github.blog/changelog/2026-01-22-1-vcpu-linux-runner-now-generally-available-in-github-actions/ "1 vCPU Linux runner now generally available in GitHub Actions"