### PR TITLE
Fix: Add missing NTF dependency

### DIFF
--- a/bin/build-manylinux.sh
+++ b/bin/build-manylinux.sh
@@ -14,6 +14,7 @@ sudo yum install -y \
     ninja-build \
     flex-devel \
     zlib-devel \
+    openssl-devel \
     m4
 PREREQUISITES
 


### PR DESCRIPTION
NTF now depends on OpenSSL, which is functionality we will eventually incorporate into the Python SDK.  However, right now this is causing our nightly wheel builds on Linux to fail.  This patch adds a dependency on the OpenSSL development package in the `build-manylinux.sh` build script.

<!-- Make sure your PR is linked to an issue as described in the
CONTRIBUTING.md document. Place the issue number under the PR description
after the '#' character. -->