### PR TITLE
Chore: Update from deprecated TOML table license identifier

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ authors = [
     {name = "Bloomberg Finance LP"}
 ]
 dynamic = ["version"]
-license = {text = "Apache-2.0"}
+license = "Apache-2.0"
 classifiers = [
     "Intended Audience :: Developers",
     "Operating System :: POSIX :: Linux",


### PR DESCRIPTION
This patch fixes a warning generated while building tests on newer versions of setuptools:

    Please use a simple string containing a SPDX expression for
    `project.license`. You can also use `project.license-files`. (Both
    options available on setuptools>=77.0.0).

The TOML table we use already contains an SPDX expression and can easily be replaced with a simple string.

This change must be done before 18 Feb 2027.