### PR TITLE
Fix: Install OpenSSL when building wheels for release

### DIFF
--- a/bin/build-manylinux.sh
+++ b/bin/build-manylinux.sh
@@ -2,21 +2,18 @@
 
 # This script builds BlazingMQ and all of its dependencies on RHEL7.
 #
-# Before running this script, install following prerequisites, if not present
-# yet, by copy-and-pasting the commands between `<<PREREQUISITES` and
-# `PREREQUISITES` below:
-                                                    # shellcheck disable=SC2188
-<<PREREQUISITES
-sudo yum install -y \
-    gdb \
-    curl \
-    pkgconfig \
-    ninja-build \
-    flex-devel \
-    zlib-devel \
-    openssl-devel \
-    m4
-PREREQUISITES
+# Before running this script, install the following prerequisites if not
+# present yet:
+#
+#   sudo yum install -y \
+#       gdb \
+#       curl \
+#       pkgconfig \
+#       ninja-build \
+#       flex-devel \
+#       zlib-devel \
+#       openssl-devel \
+#       m4
 
 set -e
 set -u

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ PKG_CONFIG_PATH="install/lib/pkgconfig"
 
 [tool.cibuildwheel.linux]
 before-all = [
-  "yum install -y gdb curl pkgconfig ninja-build flex flex-devel zlib-devel",
+  "yum install -y gdb curl pkgconfig ninja-build flex flex-devel zlib-devel openssl-devel",
   "DIR_INSTALL=/usr/local bash bin/build-manylinux.sh"
 ]
 
@@ -81,6 +81,6 @@ before-test = [
 [[tool.cibuildwheel.overrides]]
 select = "*-musllinux*"
 before-all = [
-  "apk add --update gdb curl pkgconfig ninja flex flex-dev zlib-dev",
+  "apk add --update gdb curl pkgconfig ninja flex flex-dev zlib-dev openssl-dev",
   "DIR_INSTALL=/usr/local bash bin/build-manylinux.sh"
 ]


### PR DESCRIPTION
The previous commit tried to add a dependency on OpenSSL by modifying the build script.  However, the build script modification changed an unevaluated heredoc that we were using as a comment.  This was confusing, and remains so.  Shellcheck also agrees, since we had to suppress a warning about this for it to pass.

This patch makes two changes.  First, it performs the correct installation during wheel releases, both on ManyLinux and Musllinux, by modifying the package installation commands in `pyproject.toml`. Second, it converts the heredoc we were using as a comment into an actual comment.