### PR TITLE
Fix: Remove unused environment variable

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -139,7 +139,6 @@ jobs:
           CIBW_TEST_COMMAND: python3 -m pytest {project}/tests/unit
           CIBW_TEST_REQUIRES: pytest mock pkgconfig
           MACOSX_DEPLOYMENT_TARGET: "14.0"
-          MACOS_DEPLOYMENT_TARGET: "14.0"
           SYSTEM_VERSION_COMPAT: 0
 
       - uses: actions/upload-artifact@v4


### PR DESCRIPTION
The `MACOSX_DEPLOYMENT_TARGET` environment variable is used by Xcode and clang on MacOSX and iOS to set the minimum OS version to target. The `MACOS_DEPLOYMENT_TARGET` environment variable does not seem to exist or be used by anything, in our project or externally.  This patch removes the unused environment variable.