### PR TITLE
Fix a deadlock that could occur at shutdown

### DIFF
--- a/news/80.bugfix.rst
+++ b/news/80.bugfix.rst
@@ -1,0 +1,1 @@
+Fix a deadlock that could occur at shutdown.

--- a/src/cpp/pybmq_ballutil.cpp
+++ b/src/cpp/pybmq_ballutil.cpp
@@ -15,6 +15,7 @@
 
 #include <pybmq_ballutil.h>
 #include <pybmq_gilacquireguard.h>
+#include <pybmq_gilreleaseguard.h>
 #include <pybmq_refutils.h>
 
 #include <ball_context.h>
@@ -131,8 +132,27 @@ PyObject*
 BallUtil::shutDownBallSingleton()
 {
     BALL_LOG_SET_CATEGORY("pybmq_ballutil");
+
+    if (!ball::LoggerManager::isInitialized()) {
+        Py_RETURN_NONE;
+    }
+
     BALL_LOG_DEBUG << "Shutting down BALL redirection";
-    ball::LoggerManager::shutDownSingleton();
+
+    // Since our Observer owns Python objects, it can't be destroyed with the
+    // GIL released.  Save a reference so it survives deregisterAllObservers,
+    // and it is instead destroyed after PyEval_RestoreThread.
+    bsl::shared_ptr<ball::Observer> observer =
+            ball::LoggerManager::singleton().findObserver("default");
+
+    {
+        GilReleaseGuard release_gil;
+        // Note: We leak the logger manager singleton. Destroying it could race
+        //       with some still living C++ thread that wants to log, resulting
+        //       in a crash after main.  Instead of risking that, we put it
+        //       into a state where further logs will be silently dropped.
+        ball::LoggerManager::singleton().deregisterAllObservers();
+    }
     Py_RETURN_NONE;
 }
 


### PR DESCRIPTION
Up until now, we've held the GIL while shutting down the BALL logger manager at shutdown. With recent versions of BDE, this leads to a race and a potential lock ordering deadlock. It's possible that one thread holds the GIL and blocks inside `ball::LoggerManager::shutDownSingleton` waiting for all pending log calls to finish so that it can deregister all of the observers, and meanwhile another thread is in the middle of a log call, trying to acquire the GIL so that it can forward the log record on to the Python `logging` module.

Address this problem by splitting the logging shutdown into two phases. First, we call `deregisterAllObservers` with the GIL released, which will guarantee that there are no other threads referring to our BALL observer. Then we reacquire the GIL to destroy our BALL observer, which can only be destroyed while the GIL is held because it owns Python objects.