### PR TITLE
Chore: Use Python 3.14 as default version

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -194,10 +194,10 @@ jobs:
           key: ${{ needs.blazingmq-dependency.outputs.deps_cache_key }}
       - name: Restore cached BlazingMQ build artifacts
         run: tar xzf blazingmq_artifacts.tar.gz
-      - name: Set up Python 3.9
+      - name: Set up Python 3.14
         uses: actions/setup-python@v5
         with:
-          python-version: "3.9"
+          python-version: "3.14"
       - name: Create virtual environment
         run: |
           python3 -m venv venv
@@ -245,7 +245,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.9"
+          python-version: "3.14"
       - name: Create virtual environment
         run: |
           python3 -m venv venv

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -8,8 +8,8 @@ CI to test on all other combinations in your pull request. See
 `.github/workflows/build.yaml` for more details on how we build and
 test on all supported interpreters and architectures.
 
-The instructions below assume `PYEXEC=python3.9` and will focus on Linux only.
-This should be sufficient in most cases.
+The instructions below assume `PYEXEC=python3.14` and will focus on
+Linux only.  This should be sufficient in most cases.
 
 Before following any of the instructions, make sure to `git clone` the project onto the host machine.
 

--- a/requirements-lint-docs.txt
+++ b/requirements-lint-docs.txt
@@ -1,5 +1,5 @@
 black
-flake8<5
+flake8
 isort
 mypy
 recommonmark

--- a/tests/integration/test_basic.py
+++ b/tests/integration/test_basic.py
@@ -68,8 +68,7 @@ def test_raising_in_session_callback(capsys):
 
 def test_session_stopped_atexit():
     # GIVEN
-    program = textwrap.dedent(
-        """
+    program = textwrap.dedent("""
         import blazingmq
         # make sure this works even if monkey-patched
         blazingmq._ext.ensure_stop_session = print
@@ -86,8 +85,7 @@ def test_session_stopped_atexit():
         s = blazingmq.Session(event_handler, print)
         e.wait()
         atexit.register(print, "last atexit handler")
-        """
-    )
+        """)
 
     # WHEN
     process = subprocess.Popen(
@@ -161,8 +159,7 @@ def test_session_reassignment():
 
 def test_session_ref_cycle_interpreter_shutdown(capsys):
     # GIVEN
-    program = textwrap.dedent(
-        """
+    program = textwrap.dedent("""
         import blazingmq
         import os
 
@@ -177,8 +174,7 @@ def test_session_ref_cycle_interpreter_shutdown(capsys):
 
         session1.other = session2
         session2.other = session1
-        """
-    )
+        """)
 
     # WHEN
     process = subprocess.Popen(

--- a/tests/integration/test_deadlock_detection.py
+++ b/tests/integration/test_deadlock_detection.py
@@ -27,8 +27,7 @@ import textwrap
 
 def test_deadlock_detection_warning(unique_queue):
     # GIVEN
-    program = textwrap.dedent(
-        """
+    program = textwrap.dedent("""
         import blazingmq
 
         import resource
@@ -66,8 +65,7 @@ def test_deadlock_detection_warning(unique_queue):
         main()
         message_processed.set()
         time.sleep(10)
-        """
-    ).format(unique_queue=unique_queue)
+        """).format(unique_queue=unique_queue)
 
     # WHEN
     process = subprocess.Popen(

--- a/tests/integration/test_examples.py
+++ b/tests/integration/test_examples.py
@@ -29,8 +29,7 @@ from blazingmq.session_events import log_session_event
 
 
 def script_wrapper(queue, script):
-    return textwrap.dedent(
-        """
+    return textwrap.dedent("""
             import signal
 
             import examples.{} as script
@@ -42,8 +41,7 @@ def script_wrapper(queue, script):
                 signal.signal(signal.SIGTERM, script.on_signal)
 
             script.main()
-        """
-    ).format(script, queue)
+        """).format(script, queue)
 
 
 def run_wrapper(queue, script):

--- a/tests/unit/test_ball_log_redirection.py
+++ b/tests/unit/test_ball_log_redirection.py
@@ -27,14 +27,11 @@ import pytest
 )
 def test_ball_logger_redirection(diagnostics_enabled, logger_level, emitted):
     # GIVEN
-    program = textwrap.dedent(
-        """
+    program = textwrap.dedent("""
         import blazingmq._ext
         import logging
         logging.basicConfig(level='%s')
-    """
-        % logger_level
-    )
+    """ % logger_level)
 
     env = os.environ.copy()
     if diagnostics_enabled:
@@ -59,14 +56,12 @@ def test_ball_logger_redirection(diagnostics_enabled, logger_level, emitted):
 
 def test_ball_logger_python_exception_handling():
     # GIVEN
-    program = textwrap.dedent(
-        """
+    program = textwrap.dedent("""
         import blazingmq._ext
         import logging
         logging.basicConfig(level="DEBUG")
         logging.setLogRecordFactory("something not callable")
-        """
-    )
+        """)
 
     env = os.environ.copy()
     env["_PYBMQ_ENABLE_DIAGNOSTICS"] = "1"

--- a/tests/unit/test_messages.py
+++ b/tests/unit/test_messages.py
@@ -157,7 +157,7 @@ def test_message_received_in_callback():
     spy.assert_called_once()
     args, kwargs = spy.call_args
     assert not kwargs
-    (msg, msg_handle) = args
+    msg, msg_handle = args
     assert isinstance(msg, blazingmq.Message)
     assert isinstance(msg_handle, blazingmq.MessageHandle)
     assert msg.data == raw[0]

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py39,lint, lint-cython, lint-types, black, docs
+envlist = py314,lint, lint-cython, lint-types, black, docs
 minversion = 3.2.1
 isolated_build = true
 
@@ -32,23 +32,23 @@ description =
 
 [testenv:.package]
 description = Isolated build environment
-basepython = python3.9
+basepython = python3.14
 
-[testenv:py39-cov]
+[testenv:py314-cov]
 usedevelop = True
 commands = {[testenv]commands_cov}
 deps = -rrequirements-test-coverage.txt
 
 [testenv:lint]
 description =  Run lint checker on Python files
-basepython = python3.9
+basepython = python3.14
 deps = flake8
 skip_install = true
 commands = {basepython} -m flake8 --config={toxinidir}/.flake8 src
 
 [testenv:lint-cython]
 description =  Run lint checker on Cython files
-basepython = python3.9
+basepython = python3.14
 deps = flake8
 skip_install = true
 commands = {basepython} -m flake8 --config={toxinidir}/.flake8.cython src
@@ -56,21 +56,21 @@ commands = {basepython} -m flake8 --config={toxinidir}/.flake8.cython src
 
 [testenv:lint-types]
 description =  Run mypy checker on examples
-basepython = python3.9
+basepython = python3.14
 deps = 
     mypy
 commands = {basepython} -m mypy --strict examples
 
 [testenv:black]
 description =  Check that python files are formatted with black
-basepython = python3.9
+basepython = python3.14
 deps = black
 skip_install = true
 commands = {basepython} -m black --check --verbose src tests
 
 [testenv:docs]
 description = Generate library documentation
-basepython = python3.9
+basepython = python3.14
 deps = -rrequirements-lint-docs.txt
 commands = make -C docs html
            {basepython} -c 'print("documentation available under file://{toxworkdir}/docs_out/index.html")'


### PR DESCRIPTION
Throughout the project we have scattered references to building with Python 3.9, in documentation, in our tox.ini, and in CI.  The last of those is the most important, because it means our CI builds, tests, and lints against Python 3.9, rather than a more modern version of Python.  This patch changes our defaults to Python 3.14.  This is safe, because we still build our wheels against all versions of Python in CI.