### PR TITLE
Build: Add Pythons 3.13 and 3.14 to cibuildwheel configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ filename    = "CHANGELOG.md"
 directory   = "news"
 
 [tool.cibuildwheel]
-build = ["cp39-*", "cp310-*", "cp311-*", "cp312-*"]
+build = ["cp39-*", "cp310-*", "cp311-*", "cp312-*", "cp313-*", "cp314-*"]
 skip = "*-musllinux_*"
 manylinux-x86_64-image = "manylinux2014"
 manylinux-i686-image = "manylinux2014"


### PR DESCRIPTION
Anyone who runs cibuildwheel locally to test uses the configuration block in pyproject.toml.  Right now, this only contains configuration for Python versions 3.9 through 3.12, not 3.13 or 3.14.  This configuration change is particularly difficult to remember, since it has a different structure than normal Python version strings and we tend to run cibuildwheel just in CI, explaining why we’ve forgotten this for the last two versions.  This patch adds Python versions 3.13 and 3.14 to this configuration.