### PR TITLE
Chore: Update dependabot configuration to best practices

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,5 +2,18 @@ version: 2
 updates:
   - package-ecosystem: "github-actions"
     directory: "/"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+        exclude-patterns:
+          - "actions/*"
+          - "github/*"
+      github-owned-actions:
+        patterns:
+          - "actions/*"
+          - "github/*"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
This patch updates our dependabot configuration to add a cooldown time of 7 days before issuing a pull request and to group pull requests into official GitHub Actions changes and third-party actions changes.