### PR TITLE
CI: Disable credential persistence in actions/checkout

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -22,6 +22,8 @@ jobs:
       deps_cache_key: ${{ steps.cache-key.outputs.deps_cache_key }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Compute dependency cache key
         id: cache-key
@@ -98,6 +100,8 @@ jobs:
           - "3.14"
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Try to get cached BlazingMQ build artifacts
         id: cache-restore
         uses: actions/cache/restore@v4
@@ -186,6 +190,8 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Try to get cached BlazingMQ build artifacts
         id: cache-restore
         uses: actions/cache/restore@v4
@@ -234,6 +240,8 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Try to get cached BlazingMQ build artifacts
         id: cache-restore
         uses: actions/cache/restore@v4

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -25,6 +25,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Build sdist
         env:


### PR DESCRIPTION
Set `persist-credentials: false` on `actions/checkout` steps, none of them need to push.