### PR TITLE
CI: Add Scorecard workflow for repository analysis

### DIFF
--- a/.github/workflows/scorecard.yaml
+++ b/.github/workflows/scorecard.yaml
@@ -1,0 +1,34 @@
+---
+name: Scorecard
+
+on:
+  push:
+    branches:
+      # Run on pushes to default branch
+      - main
+  schedule:
+    # Run weekly on Saturdays
+    - cron: "30 1 * * 6"
+  # Run when branch protection rules change
+  branch_protection_rule:
+  # Run the workflow manually
+  workflow_dispatch:
+
+# Declare default permissions as read-only
+permissions: read-all
+
+jobs:
+  run-scorecard:
+    # Call reusable workflow file
+    uses: bloomberg/.github/.github/workflows/_scorecard.yml@main
+    permissions:
+      id-token: write
+      security-events: write
+      checks: read
+      contents: read
+      issues: read
+      pull-requests: read
+    secrets: inherit
+    with:
+      # Publish results of Scorecard analysis
+      publish-results: true


### PR DESCRIPTION
This workflow runs the Scorecard analysis on pushes to the main branch and on a weekly schedule.
