### PR TITLE
Fix: Reject URIs with embedded NUL bytes

### DIFF
--- a/src/blazingmq/_ext.pyx
+++ b/src/blazingmq/_ext.pyx
@@ -188,6 +188,9 @@ cdef class Session:
         cdef TimeInterval c_configure_queue_timeout = create_time_interval(timeouts.configure_queue_timeout)
         cdef TimeInterval c_close_queue_timeout = create_time_interval(timeouts.close_queue_timeout)
 
+        if b'\x00' in broker:
+            raise ValueError('broker must not contain an embedded NUL byte')
+
         PyEval_InitThreads()
 
         if num_processing_threads is not None:
@@ -295,6 +298,9 @@ cdef class Session:
         cdef optional[cppbool] c_suspends_on_bad_host_health
         cdef TimeInterval c_timeout = create_time_interval(timeout)
 
+        if b'\x00' in queue_uri:
+            raise ValueError('queue_uri must not contain an embedded NUL byte')
+
         if consumer_priority is not None:
             c_consumer_priority = optional[int](consumer_priority)
 
@@ -330,6 +336,9 @@ cdef class Session:
         cdef optional[cppbool] c_suspends_on_bad_host_health
         cdef TimeInterval c_timeout = create_time_interval(timeout)
 
+        if b'\x00' in queue_uri:
+            raise ValueError('queue_uri must not contain an embedded NUL byte')
+
         if consumer_priority is not None:
             c_consumer_priority = optional[int](consumer_priority)
 
@@ -353,10 +362,17 @@ cdef class Session:
                          queue_uri not None: bytes,
                          timeout: Optional[int|float] = None) -> None:
         cdef TimeInterval c_timeout = create_time_interval(timeout)
+
+        if b'\x00' in queue_uri:
+            raise ValueError('queue_uri must not contain an embedded NUL byte')
+
         self._session.close_queue_sync(queue_uri, c_timeout)
 
     def get_queue_options(self,
                           queue_uri not None: bytes) -> object:
+        if b'\x00' in queue_uri:
+            raise ValueError('queue_uri must not contain an embedded NUL byte')
+
         return self._session.get_queue_options(queue_uri)
 
     def post(self,
@@ -364,6 +380,9 @@ cdef class Session:
              payload not None: bytes,
              properties=None,
              on_ack=None) -> None:
+        if b'\x00' in queue_uri:
+            raise ValueError('queue_uri must not contain an embedded NUL byte')
+
         self._session.post(queue_uri, payload, len(payload), properties, on_ack)
 
     def confirm(self, message not None) -> None:

--- a/src/blazingmq/_session.py
+++ b/src/blazingmq/_session.py
@@ -436,6 +436,9 @@ class Session:
 
         self._has_no_on_message = on_message is None
 
+        if b"\x00" in six.ensure_binary(broker):
+            raise ValueError("broker must not contain an embedded NUL byte")
+
         # Using our Timeouts class, preserve the old behavior of passing in a
         # simple float as a timeout.  Avoid setting the `connect_timeout` and
         # `disconnect_timeout`.
@@ -586,6 +589,9 @@ class Session:
                 " monitoring was disabled when the Session was created"
             )
 
+        if b"\x00" in six.ensure_binary(queue_uri):
+            raise ValueError("queue_uri must not contain an embedded NUL byte")
+
         self._ext.open_queue_sync(
             six.ensure_binary(queue_uri),
             read=read,
@@ -622,6 +628,9 @@ class Session:
                 respond to the request within a reasonable amount of time.
             `ValueError`: If *timeout* is not > 0.0.
         """
+        if b"\x00" in six.ensure_binary(queue_uri):
+            raise ValueError("queue_uri must not contain an embedded NUL byte")
+
         self._ext.close_queue_sync(
             six.ensure_binary(queue_uri),
             timeout=_convert_timeout(timeout),
@@ -664,6 +673,9 @@ class Session:
                 " monitoring was disabled when the Session was created"
             )
 
+        if b"\x00" in six.ensure_binary(queue_uri):
+            raise ValueError("queue_uri must not contain an embedded NUL byte")
+
         self._ext.configure_queue_sync(
             six.ensure_binary(queue_uri),
             consumer_priority=options.consumer_priority,
@@ -697,6 +709,9 @@ class Session:
             a write-only queue won't be reflected in the `QueueOptions`
             returned by a later call to *get_queue_options*.
         """
+        if b"\x00" in six.ensure_binary(queue_uri):
+            raise ValueError("queue_uri must not contain an embedded NUL byte")
+
         options = self._ext.get_queue_options(six.ensure_binary(queue_uri))
         return QueueOptions(*options)
 
@@ -743,6 +758,9 @@ class Session:
         Raises:
             `~blazingmq.Error`: If the post request was not successful.
         """
+        if b"\x00" in six.ensure_binary(queue_uri):
+            raise ValueError("queue_uri must not contain an embedded NUL byte")
+
         props: Optional[Dict[bytes, Tuple[Union[int, bytes], int]]] = None
         if properties or property_type_overrides:
             props = _collect_properties_and_types(properties, property_type_overrides)

--- a/tests/unit/test_ext_post.py
+++ b/tests/unit/test_ext_post.py
@@ -53,6 +53,20 @@ def test_post_fails_with_error(post_rc, post_error):
     assert exc.match(f"Failed to post message to .+dummy_queue queue: {post_error}")
 
 
+def test_post_queue_uri_with_embedded_nul_raises():
+    # GIVEN
+    mock = sdk_mock(start=0, stop=None)
+    session = Session(dummy_callback, _mock=mock)
+    queue_uri = QUEUE_NAME[:5] + b"\x00" + QUEUE_NAME[5:]
+
+    # WHEN
+    with pytest.raises(ValueError) as exc:
+        session.post(queue_uri, b"bladiblah")
+
+    # THEN
+    assert exc.match("queue_uri must not contain an embedded NUL byte")
+
+
 def test_post_failure_reference_not_leaked():
     # GIVEN
     mock = sdk_mock(start=0, openQueueSync=0, post=-1, stop=None)

--- a/tests/unit/test_ext_queue.py
+++ b/tests/unit/test_ext_queue.py
@@ -139,6 +139,74 @@ def test_open_options_are_correctly_propagated():
     )
 
 
+def test_open_queue_uri_with_embedded_nul_raises():
+    # GIVEN
+    mock = sdk_mock(start=0, stop=None)
+    session = Session(dummy_callback, _mock=mock)
+    queue_uri = QUEUE_NAME[:5] + b"\x00" + QUEUE_NAME[5:]
+
+    # WHEN
+    with pytest.raises(ValueError) as exc:
+        session.open_queue_sync(
+            queue_uri,
+            read=True,
+            write=True,
+            consumer_priority=0,
+            max_unconfirmed_messages=0,
+            max_unconfirmed_bytes=0,
+        )
+
+    # THEN
+    assert exc.match("queue_uri must not contain an embedded NUL byte")
+
+
+def test_close_queue_uri_with_embedded_nul_raises():
+    # GIVEN
+    mock = sdk_mock(start=0, stop=None)
+    session = Session(dummy_callback, _mock=mock)
+    queue_uri = QUEUE_NAME[:5] + b"\x00" + QUEUE_NAME[5:]
+
+    # WHEN
+    with pytest.raises(ValueError) as exc:
+        session.close_queue_sync(queue_uri)
+
+    # THEN
+    assert exc.match("queue_uri must not contain an embedded NUL byte")
+
+
+def test_configure_queue_uri_with_embedded_nul_raises():
+    # GIVEN
+    mock = sdk_mock(start=0, stop=None)
+    session = Session(dummy_callback, _mock=mock)
+    queue_uri = QUEUE_NAME[:5] + b"\x00" + QUEUE_NAME[5:]
+
+    # WHEN
+    with pytest.raises(ValueError) as exc:
+        session.configure_queue_sync(
+            queue_uri,
+            consumer_priority=0,
+            max_unconfirmed_messages=0,
+            max_unconfirmed_bytes=0,
+        )
+
+    # THEN
+    assert exc.match("queue_uri must not contain an embedded NUL byte")
+
+
+def test_get_queue_options_uri_with_embedded_nul_raises():
+    # GIVEN
+    mock = sdk_mock(start=0, stop=None)
+    session = Session(dummy_callback, _mock=mock)
+    queue_uri = QUEUE_NAME[:5] + b"\x00" + QUEUE_NAME[5:]
+
+    # WHEN
+    with pytest.raises(ValueError) as exc:
+        session.get_queue_options(queue_uri)
+
+    # THEN
+    assert exc.match("queue_uri must not contain an embedded NUL byte")
+
+
 def test_open_fails_with_timeout():
     # GIVEN
     mock = sdk_mock(start=0, openQueueSync=-2, stop=None)

--- a/tests/unit/test_ext_session.py
+++ b/tests/unit/test_ext_session.py
@@ -79,6 +79,20 @@ def test_set_broker():
     del s
 
 
+def test_broker_with_embedded_nul_raises():
+    # GIVEN
+    mock = sdk_mock(start=0, stop=None)
+    broker = b"tcp://\x00evil"
+
+    # WHEN
+    with pytest.raises(ValueError) as exc:
+        Session(dummy_callback, broker=broker, _mock=mock)
+
+    # THEN
+    assert exc.match("broker must not contain an embedded NUL byte")
+    mock.start.assert_not_called()
+
+
 def test_start_no_timeout():
     # GIVEN
     mock = sdk_mock(start=0, stop=None)

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -358,6 +358,93 @@ def test_constructing_with_bad_type_for_host_health_monitor(ext_cls):
     assert exc.match(r"host_health_monitor must be None or an instance of blazingmq\.")
 
 
+@mock.patch("blazingmq._session.ExtSession")
+def test_session_broker_with_embedded_nul_raises(ext_cls):
+    # GIVEN
+    ext_cls.mock_add_spec([])
+
+    def dummy():
+        pass
+
+    # WHEN
+    with pytest.raises(Exception) as exc:
+        Session(dummy, on_message=dummy, broker="tcp://\x00evil")
+
+    # THEN
+    assert exc.type is ValueError
+    assert exc.match("broker must not contain an embedded NUL byte")
+
+
+def test_session_open_queue_uri_with_embedded_nul_raises(ext):
+    # GIVEN
+    ext.mock_add_spec(["set_owned_by_session", "clear_owned_by_session"])
+    session = make_session()
+
+    # WHEN
+    with pytest.raises(Exception) as exc:
+        session.open_queue("queue\x00uri", read=True)
+
+    # THEN
+    assert exc.type is ValueError
+    assert exc.match("queue_uri must not contain an embedded NUL byte")
+
+
+def test_session_close_queue_uri_with_embedded_nul_raises(ext):
+    # GIVEN
+    ext.mock_add_spec(["set_owned_by_session", "clear_owned_by_session"])
+    session = make_session()
+
+    # WHEN
+    with pytest.raises(Exception) as exc:
+        session.close_queue("queue\x00uri")
+
+    # THEN
+    assert exc.type is ValueError
+    assert exc.match("queue_uri must not contain an embedded NUL byte")
+
+
+def test_session_configure_queue_uri_with_embedded_nul_raises(ext):
+    # GIVEN
+    ext.mock_add_spec(["set_owned_by_session", "clear_owned_by_session"])
+    session = make_session()
+
+    # WHEN
+    with pytest.raises(Exception) as exc:
+        session.configure_queue("queue\x00uri", options=QueueOptions())
+
+    # THEN
+    assert exc.type is ValueError
+    assert exc.match("queue_uri must not contain an embedded NUL byte")
+
+
+def test_session_get_queue_options_uri_with_embedded_nul_raises(ext):
+    # GIVEN
+    ext.mock_add_spec(["set_owned_by_session", "clear_owned_by_session"])
+    session = make_session()
+
+    # WHEN
+    with pytest.raises(Exception) as exc:
+        session.get_queue_options("queue\x00uri")
+
+    # THEN
+    assert exc.type is ValueError
+    assert exc.match("queue_uri must not contain an embedded NUL byte")
+
+
+def test_session_post_uri_with_embedded_nul_raises(ext):
+    # GIVEN
+    ext.mock_add_spec(["set_owned_by_session", "clear_owned_by_session"])
+    session = make_session()
+
+    # WHEN
+    with pytest.raises(Exception) as exc:
+        session.post("queue\x00uri", b"data")
+
+    # THEN
+    assert exc.type is ValueError
+    assert exc.match("queue_uri must not contain an embedded NUL byte")
+
+
 def test_session_open_queue(ext):
     # GIVEN
     ext.mock_add_spec(


### PR DESCRIPTION
This pull requests adds checks in two places for URI strings with embedded NUL bytes in them: at the Cython layer, and at the Python layer.  This ensures that the C++ layer, which traffics in NUL-terminated strings, does not accidentally treat such a string as shorter than the Python code intended.  It also includes tests to verify that if embedded NUL bytes are found, exceptions are raised.